### PR TITLE
Add goal entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.*
 *.orig.*
 web-build/
 web-report/
+server/tests/.coverage

--- a/server/habits/models/goal.py
+++ b/server/habits/models/goal.py
@@ -5,14 +5,15 @@ from marshmallow import fields
 
 
 class Goal(db.Model):
-    __tablename__ = 'habit_goal'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(64), nullable=False)
+    entries = db.relationship('GoalEntry', back_populates='goal')
 
 
 class GoalSchema(ma.Schema):
     id = fields.Integer()
     name = fields.String()
+    entries = fields.Nested('GoalEntrySchema', many=True, exclude=('goal_id',))
 
 
 goal_schema = GoalSchema()

--- a/server/habits/models/goal_entry.py
+++ b/server/habits/models/goal_entry.py
@@ -1,0 +1,21 @@
+from .base import db
+from .base import ma
+
+from marshmallow import fields
+
+
+class GoalEntry(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    occurred_date = db.Column(db.Date, nullable=False)
+    goal_id = db.Column(db.Integer, db.ForeignKey('goal.id'))
+    goal = db.relationship('Goal', back_populates='entries')
+
+
+class GoalEntrySchema(ma.Schema):
+    id = fields.Integer()
+    occurred_date = fields.Date()
+    goal_id = fields.Integer()
+
+
+goal_entry_schema = GoalEntrySchema()
+goal_entries_schema = GoalEntrySchema(many=True)

--- a/server/habits/routes/__init__.py
+++ b/server/habits/routes/__init__.py
@@ -1,13 +1,7 @@
-# from .habit_entry import habit_entry_blueprint
 from .goal import goal_blueprint
-# from .root_api import root_api_blueprint
+from .goal_entry import goal_entry_blueprint
 
 
 def init_app(app):
-    # app.register_blueprint(habit_entry_blueprint, url_prefix='/habit_entry')
     app.register_blueprint(goal_blueprint, url_prefix='/goal')
-#    app.register_blueprint(
-#        root_api_blueprint,
-#        url_prefix='/',
-#        template_folder='../templates',
-#        static_folder='../static')
+    app.register_blueprint(goal_entry_blueprint, url_prefix='/goal_entry')

--- a/server/habits/routes/goal.py
+++ b/server/habits/routes/goal.py
@@ -6,14 +6,15 @@ from ..models.base import db
 from .util import get_by_id, ensure_json_or_die
 
 goal_blueprint = Blueprint('goal_blueprint', __name__)
-# Allows CORS on all goal_blueprint routes, functionality comes from flask_cors.
+# Allows CORS on all goal_blueprint routes
 CORS(goal_blueprint)
+
 
 @goal_blueprint.route('/')
 def list_goal():
     all_goals = Goal.query.all()
     return jsonify({'data': goals_schema.dump(all_goals)})
- 
+
 
 @goal_blueprint.route('/<int:goal_id>')
 def get_goal(goal_id):

--- a/server/habits/routes/goal_entry.py
+++ b/server/habits/routes/goal_entry.py
@@ -1,0 +1,79 @@
+from flask import Blueprint, request, abort, jsonify
+from flask_cors import CORS
+from ..models.goal_entry import GoalEntry
+from ..models.goal_entry import goal_entries_schema, goal_entry_schema
+from ..models.goal import Goal
+
+from ..models.base import db
+from .util import get_by_id, ensure_json_or_die
+
+from datetime import datetime
+
+goal_entry_blueprint = Blueprint('goal_entry_blueprint', __name__)
+# Allows CORS on all goal_entry_blueprint routes
+CORS(goal_entry_blueprint)
+
+
+@goal_entry_blueprint.route('/')
+def list_goal_entry():
+    all_goals = GoalEntry.query.all()
+    return jsonify({'data': goal_entries_schema.dump(all_goals)})
+
+
+@goal_entry_blueprint.route('/<int:goal_entry_id>')
+def get_goal_entry(goal_entry_id):
+    goal_entry = get_by_id(GoalEntry, goal_entry_id, goal_entry_schema)
+    return jsonify({'data': goal_entry})
+
+
+@goal_entry_blueprint.route('/', methods=['POST'])
+def new_goal_entry():
+    ensure_json_or_die()
+    request_data = request.get_json()
+
+    goal_id = request_data['goal']
+    occurred_date_str = request_data['occurred_date']
+
+    occurred_date = datetime.strptime(occurred_date_str, '%Y-%m-%d').date()
+
+    goal_entry = GoalEntry(goal_id=goal_id, occurred_date=occurred_date)
+
+    goal = Goal.query.get(goal_id)
+    if goal is None:
+        abort(404)
+
+    goal.entries.append(goal_entry)
+
+    db.session.add(goal_entry)
+    db.session.commit()
+    return jsonify({'data': 'success'})
+
+
+@goal_entry_blueprint.route('/<int:goal_entry_id>', methods=['PUT'])
+def update_goal_entry(goal_entry_id):
+    ensure_json_or_die()
+    request_data = request.get_json()
+
+    goal_entry = GoalEntry.query.get(goal_entry_id)
+    if goal_entry is None:
+        abort(404)
+
+    occurred_date_str = request_data.get('occurred_date')
+    new_occurred_date = datetime.strptime(occurred_date_str, '%Y-%m-%d').date()
+
+    if new_occurred_date is not None:
+        goal_entry.occurred_date = new_occurred_date
+
+    db.session.commit()
+    return jsonify({'data': 'success'})
+
+
+@goal_entry_blueprint.route('/<int:goal_entry_id>', methods=['DELETE'])
+def delete_goal_entry(goal_entry_id):
+    goal_entry = GoalEntry.query.get(goal_entry_id)
+    if goal_entry is None:
+        abort(404)
+
+    db.session.delete(goal_entry)
+    db.session.commit()
+    return jsonify({'data': 'success'})

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -1,0 +1,4 @@
+def assert_200_json_response(return_value, expected_json):
+    assert return_value.status_code == 200
+    assert return_value.is_json
+    assert return_value.get_json() == expected_json

--- a/server/tests/test_goal.py
+++ b/server/tests/test_goal.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 import pytest
 
+from helpers import assert_200_json_response
+
 import pathmagic # noqa
 
 from habits import create_app
@@ -10,7 +12,7 @@ from habits import create_app
 @pytest.fixture
 def client():
     db_file_descriptor, db_file_name = tempfile.mkstemp()
-    pytest.path_to_test = '/goal'
+    pytest.path_to_goal = '/goal'
 
     test_config = {
         'SQLALCHEMY_TRACK_MODIFICATIONS': False,
@@ -26,12 +28,12 @@ def client():
 
 @pytest.fixture
 def one_in_db_client(client):
-    client.post('{}/'.format(pytest.path_to_test), json={'name': 'item1'})
+    client.post('{}/'.format(pytest.path_to_goal), json={'name': 'item1'})
     return client
 
 
 def test_non_json_post(client):
-    rv = client.post('{}/'.format(pytest.path_to_test), data='not_json')
+    rv = client.post('{}/'.format(pytest.path_to_goal), data='not_json')
     assert rv.status_code == 415
 
 
@@ -39,14 +41,14 @@ def test_get_list_empty_db(client):
     """Test a blank database."""
 
     expected = {'data': []}
-    rv = client.get('{}/'.format(pytest.path_to_test))
+    rv = client.get('{}/'.format(pytest.path_to_goal))
     assert_200_json_response(rv, expected)
 
 
 def test_get_elem_empty_db_404(client):
     """Ensure getting element from an empty db gives a 404"""
 
-    rv = client.get('{}/1'.format(pytest.path_to_test))
+    rv = client.get('{}/1'.format(pytest.path_to_goal))
     assert rv.status_code == 404
 
 
@@ -54,30 +56,30 @@ def test_insert_into_empty_db(client):
     """Test inserting an item into empty db"""
 
     expected = {'data': 'success'}
-    rv = client.post('{}/'.format(pytest.path_to_test), json={'name': 'item1'})
+    rv = client.post('{}/'.format(pytest.path_to_goal), json={'name': 'item1'})
     assert_200_json_response(rv, expected)
 
 
 def test_get_list_one_elem(one_in_db_client):
     """Test listing a database with one element"""
 
-    expected = {'data': [{'name': 'item1', 'id': 1}]}
-    rv = one_in_db_client.get('{}/'.format(pytest.path_to_test))
+    expected = {'data': [{'id': 1, 'name': 'item1', 'entries': []}]}
+    rv = one_in_db_client.get('{}/'.format(pytest.path_to_goal))
     assert_200_json_response(rv, expected)
 
 
 def test_get_item_one_elem(one_in_db_client):
     """Test getting the one item of a db with one item"""
 
-    expected = {'data': {'id': 1, 'name': 'item1'}}
-    rv = one_in_db_client.get('{}/1'.format(pytest.path_to_test))
+    expected = {'data': {'id': 1, 'name': 'item1', 'entries': []}}
+    rv = one_in_db_client.get('{}/1'.format(pytest.path_to_goal))
     assert_200_json_response(rv, expected)
 
 
 def test_get_item_out_of_bounds(one_in_db_client):
     """Ensure getting element 2 from db with one element gives a 404"""
 
-    rv = one_in_db_client.get('/goal/2')
+    rv = one_in_db_client.get('{}/2'.format(pytest.path_to_goal))
     assert rv.status_code == 404
 
 
@@ -85,18 +87,19 @@ def test_get_item_after_update(one_in_db_client):
     """Ensure update item actually updates the item"""
 
     expected_update_response = {'data': 'success'}
-    rv = one_in_db_client.put('/goal/1', json={'name': 'updated'})
+    json_in = {'name': 'new'}
+    rv = one_in_db_client.put('{}/1'.format(pytest.path_to_goal), json=json_in)
     assert_200_json_response(rv, expected_update_response)
 
-    expected_get_response = {'data': {'id': 1, 'name': 'updated'}}
-    rv = one_in_db_client.get('/goal/1')
+    expected_get_response = {'data': {'id': 1, 'name': 'new', 'entries': []}}
+    rv = one_in_db_client.get('{}/1'.format(pytest.path_to_goal))
     assert_200_json_response(rv, expected_get_response)
 
 
 def test_update_elem_empty_db_404(client):
     """Ensure update element on an empty database gives 404"""
 
-    rv = client.put('/goal/1', json={'name': 'updated'})
+    rv = client.put('{}/1'.format(pytest.path_to_goal), json={'name': 'new'})
     assert rv.status_code == 404
 
 
@@ -110,15 +113,9 @@ def test_delete_elem_empty_db_404(client):
 def test_list_item_after_delete(one_in_db_client):
     """Ensure deleting item actually deletes the item"""
     expected_delete_response = {'data': 'success'}
-    rv = one_in_db_client.delete('/goal/1')
+    rv = one_in_db_client.delete('{}/1'.format(pytest.path_to_goal))
     assert_200_json_response(rv, expected_delete_response)
 
     expected_list_response = {'data': []}
-    rv = one_in_db_client.get('{}/'.format(pytest.path_to_test))
+    rv = one_in_db_client.get('{}/'.format(pytest.path_to_goal))
     assert_200_json_response(rv, expected_list_response)
-
-
-def assert_200_json_response(return_value, expected_json):
-    assert return_value.status_code == 200
-    assert return_value.is_json
-    assert return_value.get_json() == expected_json

--- a/server/tests/test_goal_entry.py
+++ b/server/tests/test_goal_entry.py
@@ -1,0 +1,162 @@
+import os
+import tempfile
+import pytest
+from helpers import assert_200_json_response
+
+import pathmagic # noqa
+
+from habits import create_app
+
+
+@pytest.fixture
+def client():
+    db_file_descriptor, db_file_name = tempfile.mkstemp()
+    pytest.path_to_goal = '/goal'
+    pytest.path_to_goal_entry = '/goal_entry'
+
+    test_config = {
+        'SQLALCHEMY_TRACK_MODIFICATIONS': False,
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///{}'.format(db_file_name)
+    }
+    app = create_app(test_config=test_config)
+    with app.test_client() as client:
+        with app.app_context():
+            yield client  # this is where the testing happens!
+
+    os.close(db_file_descriptor)
+
+
+@pytest.fixture
+def one_goal_in_db_client(client):
+    client.post('{}/'.format(pytest.path_to_goal), json={'name': 'goal1'})
+    return client
+
+
+@pytest.fixture
+def one_goal_and_entry_in_db_client(one_goal_in_db_client):
+    json_in = {'goal': 1, 'occurred_date': '2020-03-20'}
+    one_goal_in_db_client.post(
+        '{}/'.format(pytest.path_to_goal_entry), json=json_in
+    )
+    return one_goal_in_db_client
+
+
+def test_non_json_post(client):
+    rv = client.post('{}/'.format(pytest.path_to_goal_entry), data='not_json')
+    assert rv.status_code == 415
+
+
+def test_get_list_empty_db(client):
+    """Test a blank database."""
+
+    expected = {'data': []}
+    rv = client.get('{}/'.format(pytest.path_to_goal_entry))
+    assert_200_json_response(rv, expected)
+
+
+def test_get_elem_empty_db_404(client):
+    """Ensure getting element from an empty db gives a 404"""
+
+    rv = client.get('{}/1'.format(pytest.path_to_goal_entry))
+    assert rv.status_code == 404
+
+
+def test_insert_into_empty_db(client):
+    """Test inserting a goal entry into empty db that has no goals"""
+
+    json_in = {'goal': 1, 'occurred_date': '2020-03-20'}
+    rv = client.post('{}/'.format(pytest.path_to_goal_entry), json=json_in)
+    assert rv.status_code == 404
+
+
+def test_get_list_one_elem(one_goal_and_entry_in_db_client):
+    """Test listing a database with one element"""
+
+    expected = {
+        'data': [{'id': 1, 'goal_id': 1, 'occurred_date': '2020-03-20'}]
+    }
+    rv = one_goal_and_entry_in_db_client.get(
+        '{}/'.format(pytest.path_to_goal_entry)
+    )
+
+    expected = {
+        'data': [{
+            'id': 1,
+            'name': 'goal1',
+            'entries': [{'id': 1, 'occurred_date': '2020-03-20'}]
+        }]
+    }
+    rv = one_goal_and_entry_in_db_client.get(
+        '{}/'.format(pytest.path_to_goal)
+    )
+    assert_200_json_response(rv, expected)
+
+
+def test_get_item_one_elem(one_goal_and_entry_in_db_client):
+    """Test getting the one item of a db with one item"""
+
+    expected = {'data': {'id': 1, 'goal_id': 1, 'occurred_date': '2020-03-20'}}
+
+    rv = one_goal_and_entry_in_db_client.get(
+        '{}/1'.format(pytest.path_to_goal_entry)
+    )
+    assert_200_json_response(rv, expected)
+
+
+def test_get_item_out_of_bounds(one_goal_and_entry_in_db_client):
+    """Ensure getting element 2 from db with one element gives a 404"""
+
+    rv = one_goal_and_entry_in_db_client.get(
+        '{}/2'.format(pytest.path_to_goal_entry)
+    )
+    assert rv.status_code == 404
+
+
+def test_get_item_after_update(one_goal_and_entry_in_db_client):
+    """Ensure update item actually updates the item"""
+
+    expected_update_response = {'data': 'success'}
+    json_in = {'occurred_date': '2020-03-19'}
+    rv = one_goal_and_entry_in_db_client.put(
+        '{}/1'.format(pytest.path_to_goal_entry), json=json_in
+    )
+    assert_200_json_response(rv, expected_update_response)
+
+    expected_get_response = {
+        'data': {'id': 1, 'goal_id': 1, 'occurred_date': '2020-03-19'}
+    }
+    rv = one_goal_and_entry_in_db_client.get(
+        '{}/1'.format(pytest.path_to_goal_entry)
+    )
+    assert_200_json_response(rv, expected_get_response)
+
+
+def test_update_elem_empty_db_404(client):
+    """Ensure update element on an empty database gives 404"""
+
+    rv = client.put(
+        '{}/1'.format(pytest.path_to_goal_entry), json={'name': 'updated'}
+    )
+    assert rv.status_code == 404
+
+
+def test_delete_elem_empty_db_404(client):
+    """Ensure delete element on an empty database gives 404"""
+
+    rv = client.delete('{}/1'.format(pytest.path_to_goal_entry))
+    assert rv.status_code == 404
+
+
+def test_list_item_after_delete(one_goal_and_entry_in_db_client):
+    """Ensure deleting item actually deletes the item"""
+    expected_delete_response = {'data': 'success'}
+    rv = one_goal_and_entry_in_db_client.delete(
+        '{}/1'.format(pytest.path_to_goal_entry)
+    )
+    assert_200_json_response(rv, expected_delete_response)
+
+    expected_list_response = {'data': []}
+    rv = one_goal_and_entry_in_db_client.get(
+        '{}/'.format(pytest.path_to_goal_entry)
+    )
+    assert_200_json_response(rv, expected_list_response)


### PR DESCRIPTION
@NicholasM1233 
I decided to take a break from react tests and give you your goal_entries as promised :) Now we can make an app that actually makes sense.

goal_entry API format is:

```
POST /goal_entry/ , data: {"goal": 1, "occurred_date": "2020-03-19"}
                            ^- goal must be id of existing goal, otherwise gives 404
  - returns: {"data": "success"}

PUT /goal_entry/<id> , data: {"occurred_date": "2020-03-18"}
  - returns: {"data": "success"}

GET /goal_entry/<id>
  - returns: {"data":{"goal_id":1,"id":1,"occurred_date":"2020-03-19"}}
  - note: this probably won't be used much, see new /goal api output below

GET /goal_entry/
  - returns: {"data":[{"goal_id":1,"id":1,"occurred_date":"2020-03-19"} , ...]}
  - note: this probably won't be used much, see new /goal api output below

DELETE /goal_entry/<id>
  - returns: {"data": "success"}
```

Goal API changes a bit to give the goal_entries:
```
GET /goal/
  - returns: {"data":[{"id":1,"name":"goal name", "entries":[{"id":1,"occurred_date":"2020-03-19"}, ...]}, ...]}
                                                  ^^^^^^^^^^^^^^^^^^^^^^^new part^^^^^^^^^^^^^^^^^^^^^^^

GET /goal/<id>
  - returns: {"data":{"id":1,"name":"goal name", "entries":[{"id":1,"occurred_date":"2020-03-19"}, ...]}}
                                                 ^^^^^^^^^^^^^^^^^^^^^^^new part^^^^^^^^^^^^^^^^^^^^^^^
```

I think our normal usage will be:
 - For creating goal entries: call `POST /goal_entry/`, giving the goal id we want it associated with
 - For retrieving goal entries associated with a goal: Use goal's GET APIs which now has an `entries` field, which gives the goal entries.

Hopefully that makes sense?

Please give any feedback you can think of or if I can make anything simpler! Thanks!